### PR TITLE
Fix bugs: stale tests, from_yaml, silent defaults, error messages

### DIFF
--- a/src/tsr/core/tsr.py
+++ b/src/tsr/core/tsr.py
@@ -248,8 +248,13 @@ class TSR:
         """
         if len(xyzrpy) != 6:
             raise ValueError('xyzrpy must be of length 6')
-        if not all(self.is_valid(xyzrpy)):
-            raise ValueError('Invalid xyzrpy', xyzrpy)
+        validity = self.is_valid(xyzrpy)
+        if not all(validity):
+            violated = [i for i, v in enumerate(validity) if not v]
+            raise ValueError(
+                f'xyzrpy violates bounds at dimensions {violated}: '
+                f'xyzrpy={xyzrpy}, bounds={self._Bw_cont[violated]}'
+            )
         Tw = TSR.xyzrpy_to_trans(xyzrpy)
         trans = reduce(numpy.dot, [self.T0_w, Tw, self.Tw_e])
         return trans
@@ -524,12 +529,8 @@ class TSR:
         return yaml.dump(self.to_dict())
 
     @staticmethod
-    def from_yaml(x, *args, **kw_args):
-        """
-        Construct a TSR from a YAML string.
-
-        This method internally forwards all arguments to `yaml.safe_load`.
-        """
+    def from_yaml(x):
+        """Construct a TSR from a YAML string."""
         import yaml
-        x_dict = yaml.safe_load(x, *args, **kw_args)
+        x_dict = yaml.safe_load(x)
         return TSR.from_dict(x_dict)

--- a/src/tsr/core/tsr_chain.py
+++ b/src/tsr/core/tsr_chain.py
@@ -73,14 +73,10 @@ class TSRChain:
         return yaml.dump(self.to_dict())
 
     @staticmethod
-    def from_yaml(x, *args, **kw_args):
-        """
-        Construct a TSR chain from a YAML string.
-
-        This method internally forwards all arguments to `yaml.safe_load`.
-        """
+    def from_yaml(x):
+        """Construct a TSR chain from a YAML string."""
         import yaml
-        x_dict = yaml.safe_load(x, *args, **kw_args)
+        x_dict = yaml.safe_load(x)
         return TSRChain.from_dict(x_dict)
 
     def is_valid(self, xyzrpy_list, ignoreNAN=False):

--- a/src/tsr/core/tsr_primitive.py
+++ b/src/tsr/core/tsr_primitive.py
@@ -82,7 +82,9 @@ def parse_line(params: Dict[str, Any]) -> np.ndarray:
     Bw = np.zeros((6, 2))
 
     axis_map = {'x': 0, 'y': 1, 'z': 2}
-    axis_idx = axis_map.get(axis, 2)
+    if axis not in axis_map:
+        raise ValueError(f"Unknown axis: {axis!r}. Must be 'x', 'y', or 'z'")
+    axis_idx = axis_map[axis]
 
     Bw[axis_idx, :] = range_val
 
@@ -500,8 +502,6 @@ def approach_to_rotation(approach: str, axis: str = 'z') -> np.ndarray:
         ])
     else:
         raise ValueError(f"Unknown approach direction: {approach}")
-
-    return np.eye(3)
 
 
 def parse_orientation(orientation: Dict[str, Any], position: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:

--- a/src/tsr/core/tsr_template.py
+++ b/src/tsr/core/tsr_template.py
@@ -226,12 +226,8 @@ class TSRTemplate:
         return yaml.dump(self.to_dict())
 
     @staticmethod
-    def from_yaml(x, *args, **kw_args):
-        """
-        Construct a TSRTemplate from a YAML string.
-
-        This method internally forwards all arguments to `yaml.safe_load`.
-        """
+    def from_yaml(x):
+        """Construct a TSRTemplate from a YAML string."""
         import yaml
-        x_dict = yaml.safe_load(x, *args, **kw_args)
+        x_dict = yaml.safe_load(x)
         return TSRTemplate.from_dict(x_dict)

--- a/tests/tsr/test_tsr_primitive.py
+++ b/tests/tsr/test_tsr_primitive.py
@@ -147,8 +147,9 @@ class TestPositionPrimitives(TestCase):
         }
         Bw = parse_cylinder(params)
 
-        self.assertEqual(Bw[0, 0], 0.04)   # radius fixed
-        self.assertEqual(Bw[0, 1], 0.04)
+        # Cylinder radius goes into Tw_e standoff, not Bw position
+        self.assertEqual(Bw[0, 0], 0.0)    # x = 0 (at axis)
+        self.assertEqual(Bw[0, 1], 0.0)
         self.assertEqual(Bw[2, 0], 0.02)   # height range
         self.assertEqual(Bw[2, 1], 0.08)
         self.assertAlmostEqual(Bw[5, 1], 2 * pi)  # full yaw
@@ -176,8 +177,10 @@ class TestPositionPrimitives(TestCase):
         }
         Bw = parse_shell(params)
 
-        self.assertEqual(Bw[0, 0], 0.03)  # radius range
-        self.assertEqual(Bw[0, 1], 0.05)
+        # Shell: radius midpoint goes to Tw_e standoff, half-thickness to Bw
+        half_thickness = (0.05 - 0.03) / 2  # 0.01
+        self.assertAlmostEqual(Bw[0, 0], -half_thickness)
+        self.assertAlmostEqual(Bw[0, 1], half_thickness)
         self.assertEqual(Bw[2, 0], 0.02)  # height range
         self.assertEqual(Bw[2, 1], 0.08)
 
@@ -234,7 +237,7 @@ class TestParsePosition(TestCase):
             'angle': [0, 360]
         }
         Bw = parse_position(position)
-        self.assertEqual(Bw[0, 0], 0.04)
+        self.assertEqual(Bw[0, 0], 0.0)  # radius goes to Tw_e, not Bw
 
     def test_unknown_type(self):
         """Test error on unknown type."""
@@ -300,7 +303,7 @@ gripper:
         result = load_template_yaml(yaml_str)
 
         self.assertEqual(result.name, 'Side grasp mug')
-        self.assertEqual(result.Bw[0, 0], 0.04)  # radius
+        self.assertEqual(result.Bw[0, 0], 0.0)  # radius goes to Tw_e standoff
         self.assertAlmostEqual(result.Bw[5, 0], deg2rad(30))  # angle min
         self.assertEqual(result.gripper['aperture'], 0.06)
 
@@ -489,8 +492,8 @@ class TestCylinderAxes(TestCase):
         }
         Bw = parse_cylinder(params)
 
-        # For x-axis cylinder: y=radius, x=height, roll varies
-        self.assertEqual(Bw[1, 0], 0.04)  # y = radius
+        # For x-axis cylinder: y=0 (at axis), x=height, roll varies
+        self.assertEqual(Bw[1, 0], 0.0)   # y = 0 (radius goes to Tw_e)
         self.assertEqual(Bw[0, 0], -0.1)  # x = height range
         self.assertEqual(Bw[0, 1], 0.1)
         self.assertAlmostEqual(Bw[3, 1], 2 * pi)  # roll varies
@@ -505,8 +508,8 @@ class TestCylinderAxes(TestCase):
         }
         Bw = parse_cylinder(params)
 
-        # For y-axis cylinder: x=radius, y=height, pitch varies
-        self.assertEqual(Bw[0, 0], 0.04)  # x = radius
+        # For y-axis cylinder: x=0 (at axis), y=height, pitch varies
+        self.assertEqual(Bw[0, 0], 0.0)   # x = 0 (radius goes to Tw_e)
         self.assertEqual(Bw[1, 0], -0.1)  # y = height range
         self.assertAlmostEqual(Bw[4, 1], 2 * pi)  # pitch varies
 


### PR DESCRIPTION
## Summary
- Fix 6 failing cylinder/shell primitive tests — expectations were stale after radius was correctly moved to Tw_e standoff
- Fix `from_yaml()` on TSR, TSRChain, TSRTemplate — remove `*args/**kw_args` that `yaml.safe_load()` doesn't accept
- Fix silent axis default in `parse_line()` — raise `ValueError` on invalid axis instead of silently defaulting to `z`
- Remove unreachable `return np.eye(3)` in `approach_to_rotation()`
- Improve `TSR.to_transform()` error message — show violated dimensions and bounds

## Test plan
- [x] All 163 tests pass (`uv run pytest tests/ -v`)
- [x] No behavior changes to core math

Fixes #14