### PR TITLE
Fix ring, disk, sphere primitives: radius not rotating with angular DOF

### DIFF
--- a/src/tsr/primitives.py
+++ b/src/tsr/primitives.py
@@ -49,21 +49,17 @@ def parse_point(params: Dict[str, Any]) -> np.ndarray:
     """
     Parse a point primitive.
 
+    A point has zero degrees of freedom — no bounds variation.
+    The x/y/z offset is handled by parse_template() which places it
+    in T_ref_tsr rather than Bw.
+
     Args:
-        params: dict with x, y, z values
+        params: dict with x, y, z values (used by parse_template, not here)
 
     Returns:
-        6x2 Bw array with fixed position, zero rotation
+        6x2 Bw array of all zeros
     """
-    x = float(params.get('x', 0))
-    y = float(params.get('y', 0))
-    z = float(params.get('z', 0))
-
-    Bw = np.zeros((6, 2))
-    Bw[0, :] = [x, x]
-    Bw[1, :] = [y, y]
-    Bw[2, :] = [z, z]
-    return Bw
+    return np.zeros((6, 2))
 
 
 def parse_line(params: Dict[str, Any]) -> np.ndarray:
@@ -141,36 +137,29 @@ def parse_ring(params: Dict[str, Any]) -> np.ndarray:
     """
     Parse a ring primitive (circle/arc around axis).
 
+    The radius is NOT encoded in Bw. Instead, it is added as a radial offset
+    to Tw_e by parse_template() so it rotates with the angular DOF.
+
     Args:
         params: dict with axis, radius, angle (degrees), and optional height
 
     Returns:
-        6x2 Bw array
+        6x2 Bw array with radial component = 0
     """
     axis = params.get('axis', 'z')
-    radius = float(params.get('radius', 0))
     angle = ensure_range_deg(params.get('angle', [0, 360]))
     height = float(params.get('height', 0))
 
     Bw = np.zeros((6, 2))
 
     if axis == 'z':
-        # Ring around z-axis: x=radius, y=0, z=height, yaw varies
-        Bw[0, :] = [radius, radius]
-        Bw[1, :] = [0, 0]
         Bw[2, :] = [height, height]
         Bw[5, :] = angle  # yaw
     elif axis == 'x':
-        # Ring around x-axis: x=height, y=radius, z=0, roll varies
         Bw[0, :] = [height, height]
-        Bw[1, :] = [radius, radius]
-        Bw[2, :] = [0, 0]
         Bw[3, :] = angle  # roll
     elif axis == 'y':
-        # Ring around y-axis: x=radius, y=height, z=0, pitch varies
-        Bw[0, :] = [radius, radius]
         Bw[1, :] = [height, height]
-        Bw[2, :] = [0, 0]
         Bw[4, :] = angle  # pitch
 
     return Bw
@@ -180,33 +169,35 @@ def parse_disk(params: Dict[str, Any]) -> np.ndarray:
     """
     Parse a disk primitive (filled circle/annulus).
 
+    Like shell, the radius midpoint is added to Tw_e by parse_template().
+    The radial variation (half-thickness) is kept in Bw.
+
     Args:
         params: dict with axis, radius (range), angle (degrees), and optional height
 
     Returns:
-        6x2 Bw array
+        6x2 Bw array with radial half-thickness centered at 0
     """
     axis = params.get('axis', 'z')
     radius = ensure_range(params.get('radius', [0, 0]))
     angle = ensure_range_deg(params.get('angle', [0, 360]))
     height = float(params.get('height', 0))
 
+    half_thickness = (radius[1] - radius[0]) / 2
+
     Bw = np.zeros((6, 2))
 
     if axis == 'z':
-        Bw[0, :] = radius  # x = radius range
-        Bw[1, :] = [0, 0]
+        Bw[0, :] = [-half_thickness, half_thickness]
         Bw[2, :] = [height, height]
         Bw[5, :] = angle  # yaw
     elif axis == 'x':
         Bw[0, :] = [height, height]
-        Bw[1, :] = radius
-        Bw[2, :] = [0, 0]
+        Bw[1, :] = [-half_thickness, half_thickness]
         Bw[3, :] = angle  # roll
     elif axis == 'y':
-        Bw[0, :] = radius
+        Bw[0, :] = [-half_thickness, half_thickness]
         Bw[1, :] = [height, height]
-        Bw[2, :] = [0, 0]
         Bw[4, :] = angle  # pitch
 
     return Bw
@@ -304,20 +295,19 @@ def parse_sphere(params: Dict[str, Any]) -> np.ndarray:
     """
     Parse a sphere primitive.
 
+    The radius is NOT encoded in Bw. Instead, it is added as a radial offset
+    to Tw_e by parse_template() so it rotates with pitch/yaw.
+
     Args:
         params: dict with radius, pitch (range), yaw (range) in degrees
 
     Returns:
-        6x2 Bw array
+        6x2 Bw array with x = 0
     """
-    radius = float(params.get('radius', 0))
     pitch = ensure_range_deg(params.get('pitch', [-90, 90]))
     yaw = ensure_range_deg(params.get('yaw', [0, 360]))
 
     Bw = np.zeros((6, 2))
-    Bw[0, :] = [radius, radius]
-    Bw[1, :] = [0, 0]
-    Bw[2, :] = [0, 0]
     Bw[4, :] = pitch
     Bw[5, :] = yaw
 
@@ -639,8 +629,33 @@ def parse_template(spec: Dict[str, Any]) -> ParsedTemplate:
 
     Tw_e = build_Tw_e(R, standoff, approach)
 
+    # For ring, disk, and sphere: add radius as a radial offset to Tw_e.
+    # Unlike cylinder/shell (where radial approach aligns standoff with
+    # the radial direction), these primitives may use non-radial approaches,
+    # so the radius is added directly in the radial direction of the TSR frame.
+    _RADIAL_INDEX = {'z': 0, 'x': 1, 'y': 0}
+
+    if ptype in ('ring', 'sphere'):
+        radius = float(position.get('radius', 0))
+        axis = position.get('axis', 'z')
+        Tw_e[_RADIAL_INDEX[axis], 3] += radius
+
+    if ptype == 'disk':
+        radius_range = ensure_range(position.get('radius', [0, 0]))
+        radius_mid = (radius_range[0] + radius_range[1]) / 2
+        axis = position.get('axis', 'z')
+        Tw_e[_RADIAL_INDEX[axis], 3] += radius_mid
+
     # T_ref_tsr is identity by default (TSR frame = reference frame)
     T_ref_tsr = np.eye(4)
+
+    # For point primitive, the offset goes into T_ref_tsr (not Bw).
+    # A point has zero DOF — Bw is all zeros, and the fixed offset
+    # shifts the TSR frame relative to the reference.
+    if ptype == 'point':
+        T_ref_tsr[0, 3] = float(position.get('x', 0))
+        T_ref_tsr[1, 3] = float(position.get('y', 0))
+        T_ref_tsr[2, 3] = float(position.get('z', 0))
 
     # Gripper info
     gripper = spec.get('gripper', None)

--- a/tests/tsr/test_tsr_primitive.py
+++ b/tests/tsr/test_tsr_primitive.py
@@ -30,17 +30,12 @@ class TestPositionPrimitives(TestCase):
     """Test position primitive parsers."""
 
     def test_parse_point(self):
-        """Test point primitive parsing."""
+        """Test point primitive — returns all-zero Bw (offset goes to T_ref_tsr)."""
         params = {'x': 0.1, 'y': 0.2, 'z': 0.3}
         Bw = parse_point(params)
 
         self.assertEqual(Bw.shape, (6, 2))
-        self.assertEqual(Bw[0, 0], 0.1)
-        self.assertEqual(Bw[0, 1], 0.1)
-        self.assertEqual(Bw[1, 0], 0.2)
-        self.assertEqual(Bw[2, 0], 0.3)
-        # Rotation should be zero
-        np.testing.assert_array_equal(Bw[3:6, :], np.zeros((3, 2)))
+        np.testing.assert_array_equal(Bw, np.zeros((6, 2)))
 
     def test_parse_point_defaults(self):
         """Test point with defaults."""
@@ -96,7 +91,7 @@ class TestPositionPrimitives(TestCase):
         self.assertEqual(Bw[2, 1], 0.3)
 
     def test_parse_ring_z(self):
-        """Test ring around z-axis."""
+        """Test ring around z-axis — radius NOT in Bw (goes to Tw_e)."""
         params = {
             'axis': 'z',
             'radius': 0.04,
@@ -105,8 +100,8 @@ class TestPositionPrimitives(TestCase):
         }
         Bw = parse_ring(params)
 
-        self.assertEqual(Bw[0, 0], 0.04)  # x = radius
-        self.assertEqual(Bw[0, 1], 0.04)
+        self.assertEqual(Bw[0, 0], 0.0)    # x = 0 (radius goes to Tw_e)
+        self.assertEqual(Bw[0, 1], 0.0)
         self.assertEqual(Bw[1, 0], 0)      # y = 0
         self.assertEqual(Bw[2, 0], 0.05)   # z = height
         self.assertAlmostEqual(Bw[5, 0], 0)          # yaw min
@@ -125,7 +120,7 @@ class TestPositionPrimitives(TestCase):
         self.assertAlmostEqual(Bw[5, 1], deg2rad(330))
 
     def test_parse_disk(self):
-        """Test disk primitive (annulus)."""
+        """Test disk primitive — half-thickness in Bw, midpoint goes to Tw_e."""
         params = {
             'axis': 'z',
             'radius': [0.03, 0.05],
@@ -133,8 +128,9 @@ class TestPositionPrimitives(TestCase):
         }
         Bw = parse_disk(params)
 
-        self.assertEqual(Bw[0, 0], 0.03)  # x = radius min
-        self.assertEqual(Bw[0, 1], 0.05)  # x = radius max
+        half_thickness = (0.05 - 0.03) / 2  # 0.01
+        self.assertAlmostEqual(Bw[0, 0], -half_thickness)
+        self.assertAlmostEqual(Bw[0, 1], half_thickness)
         self.assertAlmostEqual(Bw[5, 1], 2 * pi)
 
     def test_parse_cylinder_z(self):
@@ -185,7 +181,7 @@ class TestPositionPrimitives(TestCase):
         self.assertEqual(Bw[2, 1], 0.08)
 
     def test_parse_sphere(self):
-        """Test sphere primitive."""
+        """Test sphere primitive — radius NOT in Bw (goes to Tw_e)."""
         params = {
             'radius': 0.1,
             'pitch': [-90, 90],
@@ -193,7 +189,7 @@ class TestPositionPrimitives(TestCase):
         }
         Bw = parse_sphere(params)
 
-        self.assertEqual(Bw[0, 0], 0.1)  # radius
+        self.assertEqual(Bw[0, 0], 0.0)  # radius goes to Tw_e
         self.assertAlmostEqual(Bw[4, 0], -pi/2)  # pitch
         self.assertAlmostEqual(Bw[4, 1], pi/2)
         self.assertAlmostEqual(Bw[5, 0], 0)      # yaw
@@ -222,10 +218,10 @@ class TestParsePosition(TestCase):
     """Test the unified position parser."""
 
     def test_dispatch_point(self):
-        """Test dispatch to point parser."""
+        """Test dispatch to point parser — Bw is all zeros."""
         position = {'type': 'point', 'x': 0.1, 'y': 0.2, 'z': 0.3}
         Bw = parse_position(position)
-        self.assertEqual(Bw[0, 0], 0.1)
+        np.testing.assert_array_equal(Bw, np.zeros((6, 2)))
 
     def test_dispatch_cylinder(self):
         """Test dispatch to cylinder parser."""
@@ -329,7 +325,9 @@ standoff: 0.05
         result = load_template_yaml(yaml_str)
 
         self.assertEqual(result.name, 'Top grasp mug')
-        self.assertEqual(result.Bw[2, 0], 0.12)  # z fixed
+        # Point offset goes to T_ref_tsr, Bw is zero
+        np.testing.assert_array_equal(result.Bw[0:3, :], np.zeros((3, 2)))
+        self.assertAlmostEqual(result.T_ref_tsr[2, 3], 0.12)
 
     def test_placement_template(self):
         """Test placement template."""
@@ -610,20 +608,26 @@ orientation:
 standoff: 0.05
 """
         parsed = load_template_yaml(yaml_str)
-        tsr = TSR(T0_w=np.eye(4), Tw_e=parsed.Tw_e, Bw=parsed.Bw)
+        # Point offset is in T_ref_tsr, must compose with T0_w
+        T0_w = np.eye(4) @ parsed.T_ref_tsr
+        tsr = TSR(T0_w=T0_w, Tw_e=parsed.Tw_e, Bw=parsed.Bw)
 
-        # Sample and verify point is fixed
+        # Bw position should be zero (all freedom is in yaw only)
+        np.testing.assert_array_equal(parsed.Bw[0:3, :], np.zeros((3, 2)))
+
+        # Sample and verify the TSR produces valid transforms
         for _ in range(10):
-            xyzrpy = tsr.sample_xyzrpy()
-            self.assertAlmostEqual(xyzrpy[0], 0, places=5)
-            self.assertAlmostEqual(xyzrpy[1], 0, places=5)
-            self.assertAlmostEqual(xyzrpy[2], 0.12, places=5)
+            pose = tsr.sample()
+            self.assertEqual(pose.shape, (4, 4))
+            R = pose[0:3, 0:3]
+            self.assertTrue(np.allclose(R @ R.T, np.eye(3), atol=1e-6))
             # Yaw should vary (free)
+            xyzrpy = tsr.sample_xyzrpy()
             self.assertGreaterEqual(xyzrpy[5], -pi - 1e-6)
             self.assertLessEqual(xyzrpy[5], pi + 1e-6)
 
     def test_ring_grasp_samples_on_circle(self):
-        """Test that ring primitive samples points on a circle."""
+        """Test that ring primitive samples gripper positions on a circle."""
         yaml_str = """
 name: Ring grasp
 task: grasp
@@ -645,17 +649,18 @@ standoff: 0.03
         parsed = load_template_yaml(yaml_str)
         tsr = TSR(T0_w=np.eye(4), Tw_e=parsed.Tw_e, Bw=parsed.Bw)
 
-        # Sample and verify points lie on a ring
+        # Radius (0.05) + standoff (0.03) = 0.08 total offset in Tw_e
+        expected_dist = 0.05 + 0.03
+
+        # Sample and verify gripper positions lie on a circle
         for _ in range(20):
-            xyzrpy = tsr.sample_xyzrpy()
-            # Convert to Cartesian (x is radius, yaw rotates it)
-            x = xyzrpy[0] * np.cos(xyzrpy[5])
-            y = xyzrpy[0] * np.sin(xyzrpy[5])
-            # Distance from z-axis should be radius
+            pose = tsr.sample()
+            x, y, z = pose[0, 3], pose[1, 3], pose[2, 3]
+            # Distance from z-axis should be radius + standoff
             dist = np.sqrt(x**2 + y**2)
-            self.assertAlmostEqual(dist, 0.05, places=4)
-            # Height should be fixed
-            self.assertAlmostEqual(xyzrpy[2], 0.1, places=5)
+            self.assertAlmostEqual(dist, expected_dist, places=4)
+            # Height should be fixed at 0.1
+            self.assertAlmostEqual(z, 0.1, places=5)
 
     def test_tsr_distance_with_parsed_template(self):
         """Test distance calculation with parsed template."""
@@ -709,9 +714,11 @@ standoff: 0.05
         try:
             parsed = load_template_file(temp_path)
             self.assertEqual(parsed.name, 'Test Template')
-            self.assertEqual(parsed.Bw[0, 0], 0.1)
-            self.assertEqual(parsed.Bw[1, 0], 0.2)
-            self.assertEqual(parsed.Bw[2, 0], 0.3)
+            # Point offset goes to T_ref_tsr, Bw is zero
+            np.testing.assert_array_equal(parsed.Bw[0:3, :], np.zeros((3, 2)))
+            self.assertAlmostEqual(parsed.T_ref_tsr[0, 3], 0.1)
+            self.assertAlmostEqual(parsed.T_ref_tsr[1, 3], 0.2)
+            self.assertAlmostEqual(parsed.T_ref_tsr[2, 3], 0.3)
         finally:
             os.unlink(temp_path)
 
@@ -851,6 +858,7 @@ class TestEdgeCases(TestCase):
             'yaw': [0, 180]       # Only half rotation
         }
         Bw = parse_sphere(params)
+        self.assertEqual(Bw[0, 0], 0.0)  # radius goes to Tw_e
         self.assertAlmostEqual(Bw[4, 0], 0)
         self.assertAlmostEqual(Bw[4, 1], deg2rad(45))
         self.assertAlmostEqual(Bw[5, 0], 0)
@@ -879,3 +887,172 @@ standoff: 0.05
         self.assertEqual(parsed.Tw_e.shape, (4, 4))
         # The translation should reflect the standoff
         self.assertAlmostEqual(np.linalg.norm(parsed.Tw_e[0:3, 3]), 0.05, places=4)
+
+
+class TestGeometricCorrectness(TestCase):
+    """Tests that verify correct geometric behavior of primitives."""
+
+    def test_ring_positions_trace_circle(self):
+        """Ring with radial approach: sampled positions should trace a circle."""
+        yaml_str = """
+name: Ring test
+task: grasp
+subject: gripper
+reference: object
+position:
+  type: ring
+  axis: z
+  radius: 0.08
+  height: 0
+  angle: [0, 360]
+orientation:
+  approach: radial
+standoff: 0.05
+"""
+        parsed = load_template_yaml(yaml_str)
+        expected_radius = 0.08 + 0.05  # radius + standoff
+
+        # Verify Tw_e has the combined offset
+        self.assertAlmostEqual(parsed.Tw_e[0, 3], expected_radius, places=6)
+
+        tsr = TSR(T0_w=np.eye(4), Tw_e=parsed.Tw_e, Bw=parsed.Bw)
+        for _ in range(20):
+            pose = tsr.sample()
+            x, y, z = pose[0, 3], pose[1, 3], pose[2, 3]
+            dist = np.sqrt(x**2 + y**2)
+            self.assertAlmostEqual(dist, expected_radius, places=4)
+            self.assertAlmostEqual(z, 0.0, places=5)
+
+    def test_ring_nonradial_approach(self):
+        """Ring with non-radial approach: radius and standoff separate correctly."""
+        yaml_str = """
+name: Ring axial approach
+task: grasp
+subject: gripper
+reference: object
+position:
+  type: ring
+  axis: z
+  radius: 0.05
+  height: 0
+  angle: [0, 360]
+orientation:
+  approach: -z
+standoff: 0.03
+"""
+        parsed = load_template_yaml(yaml_str)
+        # Standoff goes along -z approach → Tw_e z offset
+        # Radius goes radially → Tw_e x offset
+        self.assertAlmostEqual(parsed.Tw_e[0, 3], 0.05, places=6)  # radius in x
+        self.assertAlmostEqual(parsed.Tw_e[2, 3], 0.03, places=6)  # standoff in z
+
+    def test_sphere_positions_on_sphere_surface(self):
+        """Sphere: sampled positions should lie on a sphere surface."""
+        yaml_str = """
+name: Sphere test
+task: handover
+subject: object
+reference: human
+position:
+  type: sphere
+  radius: 0.45
+  pitch: [-30, 30]
+  yaw: [-45, 45]
+orientation:
+  approach: -x
+standoff: 0
+"""
+        parsed = load_template_yaml(yaml_str)
+        tsr = TSR(T0_w=np.eye(4), Tw_e=parsed.Tw_e, Bw=parsed.Bw)
+
+        for _ in range(20):
+            pose = tsr.sample()
+            x, y, z = pose[0, 3], pose[1, 3], pose[2, 3]
+            dist = np.sqrt(x**2 + y**2 + z**2)
+            self.assertAlmostEqual(dist, 0.45, places=3)
+
+    def test_disk_positions_within_disk(self):
+        """Disk: sampled positions should be within the disk area."""
+        yaml_str = """
+name: Disk test
+task: place
+subject: cup
+reference: coaster
+position:
+  type: disk
+  axis: z
+  radius: [0, 0.02]
+  height: 0
+  angle: [0, 360]
+orientation:
+  approach: -z
+  yaw: free
+standoff: 0
+"""
+        parsed = load_template_yaml(yaml_str)
+        tsr = TSR(T0_w=np.eye(4), Tw_e=parsed.Tw_e, Bw=parsed.Bw)
+
+        for _ in range(20):
+            pose = tsr.sample()
+            x, y = pose[0, 3], pose[1, 3]
+            dist = np.sqrt(x**2 + y**2)
+            # Should be within disk radius (0.02) with tolerance
+            self.assertLessEqual(dist, 0.02 + 1e-6)
+
+    def test_point_offset_in_T_ref_tsr(self):
+        """Point: offset should be in T_ref_tsr, Bw should be all zeros."""
+        yaml_str = """
+name: Point test
+task: grasp
+subject: gripper
+reference: mug
+position:
+  type: point
+  x: 0.06
+  y: 0
+  z: 0.05
+orientation:
+  approach: -x
+standoff: 0.03
+"""
+        parsed = load_template_yaml(yaml_str)
+
+        # Bw should be all zeros for point
+        np.testing.assert_array_equal(parsed.Bw, np.zeros((6, 2)))
+
+        # T_ref_tsr should have the point offset
+        self.assertAlmostEqual(parsed.T_ref_tsr[0, 3], 0.06)
+        self.assertAlmostEqual(parsed.T_ref_tsr[1, 3], 0.0)
+        self.assertAlmostEqual(parsed.T_ref_tsr[2, 3], 0.05)
+
+        # Tw_e should have only the standoff
+        self.assertAlmostEqual(np.linalg.norm(parsed.Tw_e[0:3, 3]), 0.03, places=4)
+
+    def test_ring_x_axis(self):
+        """Ring around x-axis: positions trace circle in yz plane."""
+        yaml_str = """
+name: Valve ring
+task: grasp
+subject: gripper
+reference: valve
+position:
+  type: ring
+  axis: x
+  radius: 0.08
+  height: 0
+  angle: [0, 360]
+orientation:
+  approach: radial
+standoff: 0.03
+"""
+        parsed = load_template_yaml(yaml_str)
+        expected_radius = 0.08 + 0.03
+        tsr = TSR(T0_w=np.eye(4), Tw_e=parsed.Tw_e, Bw=parsed.Bw)
+
+        for _ in range(20):
+            pose = tsr.sample()
+            x, y, z = pose[0, 3], pose[1, 3], pose[2, 3]
+            # Circle in yz plane
+            dist = np.sqrt(y**2 + z**2)
+            self.assertAlmostEqual(dist, expected_radius, places=4)
+            self.assertAlmostEqual(x, 0.0, places=5)

--- a/tsr.md
+++ b/tsr.md
@@ -1,0 +1,244 @@
+# What is a TSR?
+
+A **Task Space Region** (TSR) constrains where one thing (the **subject**) can be, relative to another thing (the **reference**).
+
+A grasp TSR says: "given where the mug (reference) is, where can the gripper (subject) go?"
+A placement TSR says: "given where the table (reference) is, where can the mug (subject) go?"
+
+Same math, different roles.
+
+## The three components
+
+A TSR is defined by three matrices:
+
+| Component | What it is | Size |
+|-----------|-----------|------|
+| `T0_w` | **Reference pose** in world frame | 4×4 |
+| `Tw_e` | **Canonical subject pose** in reference frame (at Bw = 0) | 4×4 |
+| `Bw` | How much the subject can deviate from canonical | 6×2 |
+
+`Bw` has 6 rows — one per degree of freedom: `[x, y, z, roll, pitch, yaw]`. Each row is `[min, max]`. Translations are in meters, rotations in radians.
+
+### How they compose
+
+To get a concrete subject pose, pick a sample `s` from within `Bw`, then:
+
+```
+subject_pose = T0_w  @  xyzrpy_to_transform(s)  @  Tw_e
+               ────     ────────────────────────     ────
+               reference   deviation from canonical     canonical
+               pose        (within bounds)              subject pose
+```
+
+Sampling picks a random `s` within Bw and returns the resulting subject pose.
+
+## Example 1: Mug side grasp (avoiding handle)
+
+**Reference** = mug. **Subject** = gripper.
+
+"Given where the mug is, where can the gripper go to grasp it from the side, avoiding the handle?"
+
+### The YAML template
+
+```yaml
+name: Mug Side Grasp (Avoiding Handle)
+task: grasp
+subject: gripper
+reference: mug
+
+position:
+  type: cylinder
+  axis: z
+  radius: 0.04          # mug radius (4cm)
+  height: [0.03, 0.08]  # grasp zone on mug body
+  angle: [45, 315]       # avoid handle at 0°
+
+orientation:
+  approach: radial       # fingers close perpendicular to mug surface
+
+standoff: 0.05           # 5cm approach distance
+```
+
+### What this produces
+
+**`T0_w`** = reference pose in world frame — the mug's pose. Set at runtime when you know where the mug is.
+
+**`Tw_e`** = canonical subject pose in reference frame — the gripper's default pose relative to the mug. The parser combines `radial` orientation + `standoff` + `radius`:
+
+- The gripper's z-axis points radially inward (toward the mug center)
+- The gripper is offset by `radius + standoff = 0.04 + 0.05 = 0.09m` from the cylinder axis
+- At Bw = 0, the gripper is at the starting position on the cylinder surface
+
+```
+Tw_e = [0  0  -1   0.09]    gripper z → -x (points toward center)
+       [0  1   0   0   ]    gripper y → +y (finger opening direction)
+       [1  0   0   0   ]    gripper x → +z
+       [0  0   0   1   ]
+```
+
+The translation `[0.09, 0, 0]` is the standoff expressed in the TSR frame. It places the gripper 9cm out along the TSR x-axis — and when yaw rotates, this offset rotates with it, keeping the gripper on the cylinder surface.
+
+**`Bw`** = where on the cylinder the gripper is allowed:
+
+| DOF | Min | Max | Meaning |
+|-----|-----|-----|---------|
+| x | 0 | 0 | Fixed (radius is in Tw_e, not here) |
+| y | 0 | 0 | Fixed |
+| z | 0.03 | 0.08 | Height along mug body |
+| roll | 0 | 0 | Fixed |
+| pitch | 0 | 0 | Fixed |
+| yaw | 45° (0.79 rad) | 315° (5.50 rad) | Angle around mug — skips 0° where the handle is |
+
+When you sample, the yaw rotates the gripper around the mug's z-axis, and the z translation slides it up/down the mug body. The 0.09m offset in Tw_e rotates with the yaw — this is why radius goes into Tw_e, not Bw.
+
+## Example 2: Mug on table
+
+**Reference** = table. **Subject** = mug.
+
+"Given where the table is, where can the mug go?"
+
+### The YAML template
+
+```yaml
+name: Mug on Table
+task: place
+subject: mug
+reference: table
+reference_frame: bottom   # expects pose of mug's bottom surface
+
+position:
+  type: plane
+  x: [-0.15, 0.15]       # generous placement area
+  y: [-0.15, 0.15]
+  z: 0                   # table surface
+
+orientation:
+  approach: -z            # mug upright (z-up)
+  yaw: free               # any rotation around vertical
+
+standoff: 0
+```
+
+### What this produces
+
+**`T0_w`** = reference pose in world frame — the table's surface pose. Set at runtime.
+
+**`Tw_e`** = canonical subject pose in reference frame — the mug's default pose relative to the table. With `approach: -z` and zero standoff:
+
+- `approach: -z` means the subject's contact direction faces -z (downward)
+- For a mug, that means its bottom faces down — it's upright
+- This is a 180° rotation about the x-axis relative to the TSR frame
+
+```
+Tw_e = [1   0   0   0]    mug x → +x
+       [0  -1   0   0]    mug y → -y  (flipped)
+       [0   0  -1   0]    mug z → -z  (bottom faces down = upright)
+       [0   0   0   1]
+```
+
+**`Bw`** = where on the table the mug is allowed:
+
+| DOF | Min | Max | Meaning |
+|-----|-----|-----|---------|
+| x | -0.15 | 0.15 | 30cm placement area in x |
+| y | -0.15 | 0.15 | 30cm placement area in y |
+| z | 0 | 0 | On the surface (no floating) |
+| roll | 0 | 0 | Stay upright |
+| pitch | 0 | 0 | Stay upright |
+| yaw | -π | π | Any rotation around vertical |
+
+When you sample, x and y slide the mug around the table surface, and yaw rotates it. The mug stays upright because roll and pitch are locked to zero.
+
+Note: `reference_frame: bottom` tells the caller that this template's `T0_w` expects the mug's bottom-surface pose, not its center of mass. The `reference_frame` is a convenience — it's often much easier to define canonical poses and bounds relative to a specific point on the object (like the bottom of a mug, or the center of a pitcher handle) rather than the object origin. The math doesn't change; it just shifts which pose the caller passes as `T0_w`.
+
+## The key insight
+
+A TSR always answers the same question:
+
+> Given where the **reference** is (`T0_w`), where can the **subject** be?
+
+The `Tw_e` matrix defines the ideal relationship. The `Bw` bounds define the allowed variation. The math is identical whether the subject is a gripper reaching for an object or an object being placed on a surface.
+
+**Templates** store `Tw_e` and `Bw` without committing to `T0_w`. When you know the reference pose at runtime, you instantiate the template to get a concrete TSR:
+
+```python
+tsr = TSR(T0_w=mug_pose, Tw_e=template.Tw_e, Bw=template.Bw)
+grasp_pose = tsr.sample()
+```
+
+## Position primitives
+
+The `position.type` field in a template selects a geometric primitive — the shape of the region where the subject can be. Each primitive maps onto `Bw` and `Tw_e` differently.
+
+### The nine primitives
+
+| Primitive | Shape | Bw DOFs used | Example |
+|-----------|-------|-------------|---------|
+| **point** | Single point | None (all zero) | Mug handle grasp — one specific pose |
+| **line** | Line segment | 1 translation | Edge grasp along a shelf lip |
+| **plane** | Rectangle | 2 translations | Placement area on a table |
+| **box** | Box volume | 3 translations | Workspace bounds |
+| **ring** | Circle | 1 angle + height | Bowl rim grasp |
+| **disk** | Annular region | 1 angle + radial band + height | Cup on coaster |
+| **cylinder** | Cylindrical surface | 1 angle + height range | Mug side grasp |
+| **shell** | Cylindrical band | 1 angle + height range + radial band | Grasping a pipe (varying wall thickness) |
+| **sphere** | Spherical surface | pitch + yaw | Handover — present object in front of person |
+
+### Why radius goes into Tw_e
+
+The composition formula is:
+
+```
+subject_pose = T0_w  @  xyzrpy_to_transform(bw)  @  Tw_e
+```
+
+The `xyzrpy_to_transform` function builds a matrix `[R | t]` where `R` comes from the angular components and `t` from the translational components. Crucially, `R` rotates `Tw_e`'s translation — but `t` itself is **not** rotated by `R`.
+
+This means:
+- A translation in **Tw_e** rotates when Bw's angles change (it sweeps a circle/sphere)
+- A translation in **Bw** stays fixed regardless of Bw's angles (it just offsets)
+
+For ring, disk, cylinder, shell, and sphere, the radius must trace a circle as the angle varies. So radius goes into `Tw_e`, where it will be rotated by the angular DOFs in `Bw`.
+
+```
+Ring (radius=0.08, yaw varies):
+  Tw_e translation = [0.08, 0, 0]     ← radius in Tw_e
+  Bw yaw = [0°, 360°]
+
+  yaw=0°   → position = R(0°)   @ [0.08,0,0] = [0.08, 0,     0]  ✓
+  yaw=90°  → position = R(90°)  @ [0.08,0,0] = [0,    0.08,  0]  ✓
+  yaw=180° → position = R(180°) @ [0.08,0,0] = [-0.08, 0,    0]  ✓
+```
+
+If radius were in Bw's translation instead, it would not rotate — every yaw angle would offset by the same `[0.08, 0, 0]`, producing wrong positions.
+
+### How each primitive distributes parameters
+
+**Purely translational** (no rotation interaction — safe in Bw):
+- **point**: Fixed offset goes into `T_ref_tsr` (the reference-to-TSR-origin transform). Bw is all zeros.
+- **line**, **plane**, **box**: Linear ranges go directly into Bw translations.
+
+**Radial** (radius must rotate with angle — goes into Tw_e):
+- **ring**: Radius → `Tw_e` translation. Angle → Bw rotation. Height → Bw translation along axis.
+- **disk**: Radius midpoint → `Tw_e` translation. Radius half-thickness → Bw translation (radial tolerance). Angle + height → Bw.
+- **cylinder**: Radius + standoff → `Tw_e` translation. Angle + height range → Bw.
+- **shell**: Radius midpoint + standoff → `Tw_e` translation. Radius half-thickness → Bw. Angle + height range → Bw.
+- **sphere**: Radius → `Tw_e` translation. Pitch + yaw → Bw rotations.
+
+### Standoff and approach direction
+
+The `standoff` adds distance along the **approach direction** (the direction the subject faces when contacting the reference). For a radial approach on a cylinder, standoff adds to the radius in `Tw_e`. For a top-down approach (`-z`) on a disk, standoff is along z while radius is along x — they're independent components in `Tw_e`.
+
+The `orientation.approach` field sets the rotation part of `Tw_e`, determining which direction the subject "faces." Common values:
+- `radial` — outward from the primitive's axis (for grasping cylinders, rings)
+- `-z` — downward (for placements, top grasps)
+- `-x` — toward the reference (for handovers)
+
+## Naming conventions
+
+The original TSR paper uses `T0_w` (world-to-TSR), `Tw_e` (TSR-to-end-effector), and `Bw` (bounds in TSR frame). The "end-effector" language comes from the grasp case where the subject is always a gripper. In placement TSRs, the "end-effector" is actually the object being placed.
+
+In this library:
+- **reference** = the entity whose pose defines `T0_w` (mug for grasps, table for placements)
+- **subject** = the entity whose pose is being constrained (gripper for grasps, mug for placements)
+- The YAML templates use `subject:` and `reference:` explicitly


### PR DESCRIPTION
## Summary
- Ring, disk, and sphere primitives placed radius in `Bw` (translational bounds), but `Bw` translations don't rotate with `Bw` angular DOFs in the TSR composition formula. Positions stayed at a fixed offset instead of sweeping circles/spheres.
- Fix: move radius into `Tw_e` (like cylinder/shell already do), where it rotates correctly with yaw/roll/pitch.
- Also fix point primitive: move fixed offset from `Bw` (degenerate bounds) to `T_ref_tsr`, making `Bw` truly zero for zero-DOF poses.

## Test plan
- [x] 53 primitive-specific tests pass (6 new geometric verification tests)
- [x] Full suite: 166 tests pass
- [x] Ring: sampled positions verified to trace circles at correct radius
- [x] Sphere: sampled positions verified to lie on sphere surface
- [x] Disk: sampled positions verified within disk bounds
- [x] Point: T_ref_tsr has offset, Bw is all zeros
- [x] Ring with non-radial approach: radius and standoff separate correctly

Fixes #20