### PR TITLE
feat(hands): add FrankaHand and remove Robotiq2F140 frame correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,23 @@ place     = load_package_template("places", "mug_on_table.yaml")
 
 #### Grasping
 
-`ParallelJawGripper` generates TSR templates directly from shape parameters:
+`ParallelJawGripper` generates TSR templates directly from shape parameters.
+Pre-configured subclasses are provided for common grippers:
+
+| Class | `finger_length` | `max_aperture` | Notes |
+|---|---|---|---|
+| `Robotiq2F140` | 55 mm | 140 mm | Robotiq 2F-140 parallel gripper |
+| `FrankaHand` | 44.5 mm | 80 mm | Franka Emika Panda hand |
 
 ```python
 import numpy as np
-from tsr.hands import ParallelJawGripper
+from tsr.hands import ParallelJawGripper, Robotiq2F140, FrankaHand
 
+# Use a pre-configured gripper for a known hardware platform
+gripper = Robotiq2F140()
+gripper = FrankaHand()
+
+# Or configure manually for custom hardware
 gripper = ParallelJawGripper(finger_length=0.055, max_aperture=0.140)
 
 # Cylinder — side + top + bottom: 4*k templates (default k=3: 12 total)

--- a/src/tsr/hands/__init__.py
+++ b/src/tsr/hands/__init__.py
@@ -12,13 +12,14 @@ Usage::
     pose = tsr.sample()
 """
 from .base import GripperBase
-from .parallel_jaw import ParallelJawGripper, Robotiq2F140
+from .parallel_jaw import ParallelJawGripper, Robotiq2F140, FrankaHand
 from .registry import HandRegistry, default_registry
 
 __all__ = [
     "GripperBase",
     "ParallelJawGripper",
     "Robotiq2F140",
+    "FrankaHand",
     "HandRegistry",
     "default_registry",
 ]

--- a/src/tsr/hands/parallel_jaw.py
+++ b/src/tsr/hands/parallel_jaw.py
@@ -1,7 +1,6 @@
 """Parallel jaw gripper hand models."""
 from __future__ import annotations
 
-import dataclasses
 from typing import List, Optional, Tuple
 
 import numpy as np
@@ -914,33 +913,16 @@ class ParallelJawGripper(GripperBase):
         )
 
 
-# −90° z-rotation: corrects Robotiq wrist frame to canonical TSR EE frame.
-# The Robotiq 2F-140 physical flange zero-pose is rotated −90° around z
-# relative to the canonical frame (z=approach, y=opening, x=palm).
-_R_z_neg90 = np.array([
-    [ 0.,  1.,  0.,  0.],
-    [-1.,  0.,  0.,  0.],
-    [ 0.,  0.,  1.,  0.],
-    [ 0.,  0.,  0.,  1.],
-])
-
-
 class Robotiq2F140(ParallelJawGripper):
     """Robotiq 2F-140 parallel gripper.
 
     Fixed hardware parameters: finger_length=55 mm, max_aperture=140 mm.
 
-    Applies a −90° z-rotation correction to Tw_e so sampled poses are in
-    the Robotiq physical wrist frame rather than the canonical TSR EE frame.
-
-    Usage::
-
-        gripper   = Robotiq2F140()
-        templates = gripper.grasp_cylinder(cylinder_radius=0.04,
-                                           cylinder_height=0.10,
-                                           reference="mug")
-        tsr  = templates[0].instantiate(mug_pose)
-        pose = tsr.sample()   # pose in Robotiq wrist frame
+    Outputs poses in the canonical TSR EE frame (z=approach, y=finger-opening,
+    x=palm normal). The corresponding MuJoCo model (geodude_assets 2f140.xml)
+    defines a ``grasp_site`` at the palm with this orientation baked in — use
+    that site as the arm's ``ee_site`` so IK targets the canonical frame
+    directly.
     """
 
     FINGER_LENGTH = 0.055
@@ -952,35 +934,26 @@ class Robotiq2F140(ParallelJawGripper):
             max_aperture=self.MAX_APERTURE,
         )
 
-    def _apply_frame_correction(self, templates: List[TSRTemplate]) -> List[TSRTemplate]:
-        return [dataclasses.replace(t, Tw_e=t.Tw_e @ _R_z_neg90) for t in templates]
 
-    def grasp_cylinder_side(self, *args, **kwargs) -> List[TSRTemplate]:
-        return self._apply_frame_correction(super().grasp_cylinder_side(*args, **kwargs))
+class FrankaHand(ParallelJawGripper):
+    """Franka Emika Panda hand (parallel jaw gripper).
 
-    def grasp_cylinder_top(self, *args, **kwargs) -> List[TSRTemplate]:
-        return self._apply_frame_correction(super().grasp_cylinder_top(*args, **kwargs))
+    Fixed hardware parameters derived from the menagerie hand.xml model:
+      finger_length = 44.5 mm  (fingertip pad centre from finger-joint origin)
+      max_aperture  =  80 mm   (2 × 40 mm joint range)
 
-    def grasp_cylinder_bottom(self, *args, **kwargs) -> List[TSRTemplate]:
-        return self._apply_frame_correction(super().grasp_cylinder_bottom(*args, **kwargs))
+    The canonical EE frame (z=approach, y=finger-opening, x=palm normal)
+    matches the Franka hand body axes directly — the ``add_franka_ee_site``
+    helper in ``mj_manipulator.arms.franka`` places a ``grasp_site`` at the
+    finger-joint origin (palm) with identity orientation. Use that site as the
+    arm's ``ee_site`` so IK targets the canonical frame directly.
+    """
 
-    def grasp_box_top(self, *args, **kwargs) -> List[TSRTemplate]:
-        return self._apply_frame_correction(super().grasp_box_top(*args, **kwargs))
+    FINGER_LENGTH = 0.0445   # fingertip pad centre from finger-joint origin [m]
+    MAX_APERTURE  = 0.080    # 2 × 40 mm joint range [m]
 
-    def grasp_box_bottom(self, *args, **kwargs) -> List[TSRTemplate]:
-        return self._apply_frame_correction(super().grasp_box_bottom(*args, **kwargs))
-
-    def grasp_box_face_x(self, *args, **kwargs) -> List[TSRTemplate]:
-        return self._apply_frame_correction(super().grasp_box_face_x(*args, **kwargs))
-
-    def grasp_box_face_y(self, *args, **kwargs) -> List[TSRTemplate]:
-        return self._apply_frame_correction(super().grasp_box_face_y(*args, **kwargs))
-
-    def grasp_sphere(self, *args, **kwargs) -> List[TSRTemplate]:
-        return self._apply_frame_correction(super().grasp_sphere(*args, **kwargs))
-
-    def grasp_torus_side(self, *args, **kwargs) -> List[TSRTemplate]:
-        return self._apply_frame_correction(super().grasp_torus_side(*args, **kwargs))
-
-    def grasp_torus_span(self, *args, **kwargs) -> List[TSRTemplate]:
-        return self._apply_frame_correction(super().grasp_torus_span(*args, **kwargs))
+    def __init__(self):
+        super().__init__(
+            finger_length=self.FINGER_LENGTH,
+            max_aperture=self.MAX_APERTURE,
+        )

--- a/tests/tsr/hands/test_robotiq.py
+++ b/tests/tsr/hands/test_robotiq.py
@@ -3,7 +3,6 @@ import unittest
 import numpy as np
 
 from tsr.hands import ParallelJawGripper, Robotiq2F140
-from tsr.hands.parallel_jaw import _R_z_neg90
 
 
 class TestRobotiq2F140(unittest.TestCase):
@@ -18,18 +17,20 @@ class TestRobotiq2F140(unittest.TestCase):
     def test_is_subclass_of_parallel_jaw(self):
         self.assertIsInstance(self.gripper, ParallelJawGripper)
 
-    def test_tw_e_rotation_correction_applied(self):
+    def test_outputs_canonical_frames(self):
+        # Robotiq2F140 now outputs canonical TSR EE poses (no frame correction).
+        # It should produce identical Tw_e as a plain ParallelJawGripper with
+        # the same hardware parameters.
         base      = ParallelJawGripper(finger_length=0.055, max_aperture=0.140)
         t_base    = base.grasp_cylinder_side(0.040, 0.10)
         t_robotiq = self.gripper.grasp_cylinder_side(0.040, 0.10)
 
         self.assertEqual(len(t_base), len(t_robotiq))
         for tb, tr in zip(t_base, t_robotiq):
-            expected = tb.Tw_e @ _R_z_neg90
-            np.testing.assert_allclose(tr.Tw_e, expected, atol=1e-10)
+            np.testing.assert_allclose(tr.Tw_e, tb.Tw_e, atol=1e-10)
 
-    def test_corrected_tw_e_is_valid_se3(self):
-        templates = self.gripper.grasp_cylinder(0.040, 0.10)
+    def test_tw_e_is_valid_se3(self):
+        templates = self.gripper.grasp_cylinder_side(0.040, 0.10)
         for t in templates:
             R = t.Tw_e[:3, :3]
             np.testing.assert_allclose(R @ R.T, np.eye(3), atol=1e-10)


### PR DESCRIPTION
## Summary

- Add `FrankaHand` — a pre-configured `ParallelJawGripper` for the Franka Emika Panda with hardware parameters from the MuJoCo menagerie `hand.xml` model (`finger_length=44.5mm`, `max_aperture=80mm`)
- Remove the `-90° z-rotation` frame correction from `Robotiq2F140`. The geodude_assets `2f140.xml` defines `grasp_site` with the canonical TSR EE orientation already baked in, so the correction was being double-applied. `Robotiq2F140` now outputs canonical TSR EE poses directly, consistent with all other grippers.
- Update README with a gripper comparison table showing `Robotiq2F140` and `FrankaHand` side by side.

## Test plan

- [x] All 301 existing tests pass (`uv run pytest tests/ -v`)
- [x] `test_robotiq.py` updated to reflect that `Robotiq2F140` now outputs canonical frames (no frame correction)
- [x] `FrankaHand` verified end-to-end in `mj_manipulator` recycling demo with `mujoco_menagerie` Franka model — IK accuracy 0mm/0°