### PR TITLE
Bump dependency lower bounds to resolve Dependabot alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,21 +27,21 @@ classifiers = [
 ]
 keywords = ["robotics", "motion-planning", "task-space-regions", "tsr"]
 dependencies = [
-    "numpy>=1.20.0",
-    "scipy>=1.7.0",
-    "pyyaml>=5.4.0",
+    "numpy>=1.24.0",
+    "scipy>=1.10.0",
+    "pyyaml>=6.0.1",
 ]
 
 [project.optional-dependencies]
 test = [
-    "pytest>=6.0.0",
-    "pytest-cov>=2.10.0",
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
     "build>=1.0.0",
 ]
 viz = [
     "pyvista>=0.43.0",
-    "matplotlib>=3.5.0",
-    "Pillow>=9.0.0",
+    "matplotlib>=3.8.0",
+    "Pillow>=10.3.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
Resolves all 9 Dependabot alerts by bumping lower bounds on declared dependencies.

## Changes
- `numpy>=1.20` → `>=1.24`, `scipy>=1.7` → `>=1.10`, `pyyaml>=5.4` → `>=6.0.1`
- `pytest>=6.0` → `>=7.0`, `pytest-cov>=2.10` → `>=4.0`
- `matplotlib>=3.5` → `>=3.8`, `Pillow>=9.0` → `>=10.3`

The transitive alerts (urllib3, requests, Pygments, fonttools) resolve automatically — the bumped top-level deps require versions that pull safe transitives.

## Testing
- [x] `uv run pytest tests/ -v` — 307 passed

## Related
Fixes personalrobotics/robot-code#5