### PR TITLE
Fix CI: bump requires-python to >=3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 maintainers = [
     {name = "Siddhartha Srinivasa", email = "siddhartha.srinivasa@gmail.com"}
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -22,6 +22,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,11 @@ viz = [
     "Pillow>=10.3.0",
 ]
 
+[dependency-groups]
+dev = [
+    "ruff>=0.6.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/personalrobotics/tsr"
 Repository = "https://github.com/personalrobotics/tsr"


### PR DESCRIPTION
## Problem

CI has been red on all PRs and on main since April 5 ([#44](https://github.com/personalrobotics/tsr/pull/44) — "Bump dependency lower bounds to resolve Dependabot alerts"). Two separate failures stacked on top of each other:

1. **Dependency resolution fails**: `uv sync --all-extras --dev` can't resolve because the `viz` extra requires `matplotlib>=3.8.0` but modern matplotlib versions dropped Python 3.8/3.9 support, while `requires-python = ">=3.8"` asks for those versions.
2. **ruff not installed**: even if (1) passed, `uv run ruff check .` couldn't spawn ruff because it wasn't in any dependency group.

## Fix

Two small changes to `pyproject.toml`:

- Bump `requires-python` from `">=3.8"` to `">=3.10"` to match:
  - The actual CI matrix (`[3.10, 3.11, 3.12]` in `.github/workflows/ci.yml`)
  - The matplotlib constraint already imposed by the `viz` extra
- Add `[dependency-groups].dev = ["ruff>=0.6.0"]` so `uv sync --dev` installs ruff for the lint step.

Also added `Programming Language :: Python :: 3.10/3.11/3.12` classifiers that were missing from the metadata.

## Risk

Minimal. No code changes. Anyone pinned to Python 3.8/3.9 was already broken by #44 (the `viz` extra simply couldn't install); this PR just makes the reality explicit in the metadata.

## Verified

- Local: `uv sync --all-extras --dev` resolves cleanly, installs ruff 0.15.x.
- Local: 307 pytest tests pass; `ruff check` and `ruff format --check` both clean.
- CI: all three Python versions (3.10/3.11/3.12) green on this PR.

## Why this matters

Unblocks:
- personalrobotics/tsr#46 (Robotiq2F85 hand class) — will go green after this merges and #46 rebases onto main.
- Any future tsr PR that needs CI.