### PR TITLE
Fix FrankaHand params: palm at hand body forward edge

### DIFF
--- a/src/tsr/hands/parallel_jaw.py
+++ b/src/tsr/hands/parallel_jaw.py
@@ -1163,19 +1163,35 @@ class Robotiq2F85(ParallelJawGripper):
 class FrankaHand(ParallelJawGripper):
     """Franka Emika Panda hand (parallel jaw gripper).
 
-    Fixed hardware parameters derived from the menagerie hand.xml model:
-      finger_length = 44.5 mm  (fingertip pad centre from finger-joint origin)
-      max_aperture  =  80 mm   (2 × 40 mm joint range)
+    Fixed hardware parameters measured from the menagerie ``hand.xml``
+    model via ``mj_manipulator/scripts/validate_gripper.py``, which walks
+    each collision geom's AABB along the approach axis:
+
+    - ``FINGER_LENGTH = 0.037 m`` — distance from the **forward edge of
+      the hand body** (the TSR "palm") to the pad-contact midpoint.
+      The menagerie ``hand`` body extends 16.9 mm past the finger-joint
+      origin along the approach axis (the metal collar around the
+      finger mounts). ``FINGER_LENGTH`` must be measured from *that*
+      forward edge so the TSR's "everything behind the palm is clear
+      space" assumption holds — same failure mode that bit the 2F-85.
+    - ``MAX_APERTURE = 0.080 m`` — 2 × 40 mm joint range. Unchanged.
 
     The canonical EE frame (z=approach, y=finger-opening, x=palm normal)
-    matches the Franka hand body axes directly — the ``add_franka_ee_site``
-    helper in ``mj_manipulator.arms.franka`` places a ``grasp_site`` at the
-    finger-joint origin (palm) with identity orientation. Use that site as the
-    arm's ``ee_site`` so IK targets the canonical frame directly.
+    matches the Franka hand body axes directly. The ``add_franka_ee_site``
+    helper in ``mj_manipulator.arms.franka`` places a ``grasp_site`` at
+    ``hand + [0, 0, 0.0753]`` (= finger-joint origin + 17 mm forward)
+    with identity orientation. Use that site as the arm's ``ee_site``.
     """
 
-    FINGER_LENGTH = 0.054  # fingertip (pad tip) from finger-joint origin [m]
+    FINGER_LENGTH = 0.037  # palm (housing forward edge) → pad-mid [m]
     MAX_APERTURE = 0.080  # 2 × 40 mm joint range [m]
+
+    # Distance from the ``hand`` body origin to the TSR palm along the
+    # approach axis. Callers placing a grasp_site in an MjSpec should
+    # offset it by ``finger_joint_offset + PALM_OFFSET_FROM_HAND``.
+    # For menagerie hand.xml, finger_joint_offset = 0.0584 m, so the
+    # canonical grasp_site position is hand + [0, 0, 0.0753].
+    PALM_OFFSET_FROM_HAND = 0.0753
 
     def __init__(self):
         super().__init__(


### PR DESCRIPTION
## Summary

Symmetrical fix to #46 (Robotiq2F85). The menagerie Franka hand's \`hand\` body extends 16.9 mm past the finger-joint origin along the approach axis (the metal collar around the finger mounts). Declaring \`FINGER_LENGTH = 0.054\` (finger-joint origin → pad) and placing \`grasp_site\` at the finger-joint origin buried the TSR "palm" inside that collar. Deep-grasp templates then drove the collar into the object — 33 % of sampled grasps in collision.

Detected automatically by \`validate_gripper.py\` in personalrobotics/mj_manipulator#128:

\`\`\`
Diagnosis: the colliding geom(s) extend 16.9 mm forward of grasp_site.
TSR assumes everything except fingers is behind the palm — that's violated here.

Suggested fix:
  1. Move grasp_site forward by 0.017 m along the approach axis.
  2. Reduce FINGER_LENGTH: 0.054 → 0.037 m.
\`\`\`

## Changes

- \`FINGER_LENGTH\`: 0.054 → 0.037 m  (palm forward edge → pad-mid)
- Add \`PALM_OFFSET_FROM_HAND = 0.0753\` m class constant for callers. \`0.0753 = 0.0584 (finger-joint origin in hand frame) + 0.0169 (collar forward extent)\`.
- \`MAX_APERTURE\` unchanged (still 0.080 m).
- Docstring updated to explain the palm-vs-finger-joint-origin distinction.

## Paired PR

mj_manipulator's \`add_franka_ee_site\` needs to place \`grasp_site\` at \`hand + [0, 0, 0.0753]\` instead of \`[0, 0, 0.0584]\`. That's in a companion PR against personalrobotics/mj_manipulator.

After both merge, \`validate_gripper.py --gripper franka\` reports PASS ✓.

## Risk

Net zero motion change. Palm moves forward 17 mm, FL shrinks by 17 mm, fingertip world pose stays identical. Only the *label* "palm" on the gripper moves.

## Verified

- 314 pytests pass
- \`ruff check\` / \`ruff format --check\` clean

Fixes personalrobotics/mj_manipulator#129.